### PR TITLE
Update createInvoice to return Invoice instead of InvoiceData.

### DIFF
--- a/lightspark-sdk/src/commonJvmAndroidMain/kotlin/com/lightspark/sdk/LightsparkFuturesClient.kt
+++ b/lightspark-sdk/src/commonJvmAndroidMain/kotlin/com/lightspark/sdk/LightsparkFuturesClient.kt
@@ -12,6 +12,7 @@ import com.lightspark.sdk.model.BitcoinNetwork
 import com.lightspark.sdk.model.CreateApiTokenOutput
 import com.lightspark.sdk.model.CurrencyAmount
 import com.lightspark.sdk.model.FeeEstimate
+import com.lightspark.sdk.model.Invoice
 import com.lightspark.sdk.model.InvoiceData
 import com.lightspark.sdk.model.InvoiceType
 import com.lightspark.sdk.model.OutgoingPayment
@@ -21,7 +22,6 @@ import java.util.concurrent.CompletableFuture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.future
-import kotlinx.coroutines.runBlocking
 
 /**
  * Main entry point for the Lightspark SDK using the Java Futures API.
@@ -117,6 +117,7 @@ class LightsparkFuturesClient(config: ClientConfig) {
      * @param amountMsats The amount of the invoice in milli-satoshis.
      * @param memo Optional memo to include in the invoice.
      * @param type The type of invoice to create. Defaults to [InvoiceType.STANDARD].
+     * @param expirySecs The number of seconds until the invoice expires. Defaults to 1 day.
      */
     @JvmOverloads
     fun createInvoice(
@@ -124,8 +125,9 @@ class LightsparkFuturesClient(config: ClientConfig) {
         amountMsats: Long,
         memo: String? = null,
         type: InvoiceType = InvoiceType.STANDARD,
-    ): CompletableFuture<InvoiceData> =
-        coroutineScope.future { coroutinesClient.createInvoice(nodeId, amountMsats, memo, type) }
+        expirySecs: Int? = null,
+    ): CompletableFuture<Invoice> =
+        coroutineScope.future { coroutinesClient.createInvoice(nodeId, amountMsats, memo, type, expirySecs) }
 
     /**
      * Creates a Lightning invoice for the given node. This should only be used for generating invoices for LNURLs, with
@@ -135,14 +137,16 @@ class LightsparkFuturesClient(config: ClientConfig) {
      * @param amountMsats The amount of the invoice in milli-satoshis.
      * @param metadata The LNURL metadata payload field from the initial payreq response. This will be hashed and
      * present in the h-tag (SHA256 purpose of payment) of the resulting Bolt 11 invoice.
+     * @param expirySecs The number of seconds until the invoice expires. Defaults to 1 day.
      */
     @JvmOverloads
     fun createLnurlInvoice(
         nodeId: String,
         amountMsats: Long,
-        metadata: String
-    ): CompletableFuture<InvoiceData> =
-        coroutineScope.future { coroutinesClient.createLnurlInvoice(nodeId, amountMsats, metadata) }
+        metadata: String,
+        expirySecs: Int? = null,
+    ): CompletableFuture<Invoice> =
+        coroutineScope.future { coroutinesClient.createLnurlInvoice(nodeId, amountMsats, metadata, expirySecs) }
 
     /**
      * Pay a lightning invoice for the given node.

--- a/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/LightsparkSyncClient.kt
+++ b/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/LightsparkSyncClient.kt
@@ -107,6 +107,7 @@ class LightsparkSyncClient constructor(config: ClientConfig) {
      * @param amountMsats The amount of the invoice in milli-satoshis.
      * @param memo Optional memo to include in the invoice.
      * @param type The type of invoice to create. Defaults to [InvoiceType.STANDARD].
+     * @param expirySecs The number of seconds until the invoice expires. Defaults to 1 day.
      */
     @JvmOverloads
     fun createInvoice(
@@ -114,7 +115,8 @@ class LightsparkSyncClient constructor(config: ClientConfig) {
         amountMsats: Long,
         memo: String? = null,
         type: InvoiceType = InvoiceType.STANDARD,
-    ): InvoiceData = runBlocking { asyncClient.createInvoice(nodeId, amountMsats, memo, type) }
+        expirySecs: Int? = null,
+    ): Invoice = runBlocking { asyncClient.createInvoice(nodeId, amountMsats, memo, type, expirySecs) }
 
     /**
      * Creates a Lightning invoice for the given node. This should only be used for generating invoices for LNURLs, with
@@ -124,13 +126,15 @@ class LightsparkSyncClient constructor(config: ClientConfig) {
      * @param amountMsats The amount of the invoice in milli-satoshis.
      * @param metadata The LNURL metadata payload field from the initial payreq response. This will be hashed and
      * present in the h-tag (SHA256 purpose of payment) of the resulting Bolt 11 invoice.
+     * @param expirySecs The number of seconds until the invoice expires. Defaults to 1 day.
      */
     @JvmOverloads
     fun createLnurlInvoice(
         nodeId: String,
         amountMsats: Long,
-        metadata: String
-    ): InvoiceData = runBlocking { asyncClient.createLnurlInvoice(nodeId, amountMsats, metadata) }
+        metadata: String,
+        expirySecs: Int? = null,
+    ): Invoice = runBlocking { asyncClient.createLnurlInvoice(nodeId, amountMsats, metadata, expirySecs) }
 
     /**
      * Pay a lightning invoice for the given node.

--- a/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/graphql/CreateInvoice.kt
+++ b/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/graphql/CreateInvoice.kt
@@ -1,6 +1,6 @@
 package com.lightspark.sdk.graphql
 
-import com.lightspark.sdk.model.InvoiceData
+import com.lightspark.sdk.model.Invoice
 
 const val CreateInvoiceMutation = """
   mutation CreateInvoice(
@@ -8,15 +8,14 @@ const val CreateInvoiceMutation = """
     ${'$'}amountMsats: Long!
     ${'$'}memo: String
     ${'$'}type: InvoiceType = null
+    ${'$'}expirySecs: Int = null
     ) {
-    create_invoice(input: { node_id: ${'$'}nodeId, amount_msats: ${'$'}amountMsats, memo: ${'$'}memo, invoice_type: ${'$'}type }) {
+    create_invoice(input: { node_id: ${'$'}nodeId, amount_msats: ${'$'}amountMsats, memo: ${'$'}memo, invoice_type: ${'$'}type, expiry_secs: ${'$'}expirySecs }) {
       invoice {
-        data {
-          ...InvoiceDataFragment
-        }
+        ...InvoiceFragment
       }
     }
   }
   
-    ${InvoiceData.FRAGMENT}
+    ${Invoice.FRAGMENT}
 """

--- a/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/graphql/CreateLnurlInvoice.kt
+++ b/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/graphql/CreateLnurlInvoice.kt
@@ -1,21 +1,20 @@
 package com.lightspark.sdk.graphql
 
-import com.lightspark.sdk.model.InvoiceData
+import com.lightspark.sdk.model.Invoice
 
 const val CreateLnurlInvoiceMutation = """
   mutation CreateLnurlInvoice(
     ${'$'}nodeId: ID!
     ${'$'}amountMsats: Long!
     ${'$'}metadataHash: String!
+    ${'$'}expirySecs: Int = null
     ) {
-    create_lnurl_invoice(input: { node_id: ${'$'}nodeId, amount_msats: ${'$'}amountMsats, metadata_hash: ${'$'}metadataHash }) {
+    create_lnurl_invoice(input: { node_id: ${'$'}nodeId, amount_msats: ${'$'}amountMsats, metadata_hash: ${'$'}metadataHash, expiry_secs: ${'$'}expirySecs }) {
       invoice {
-        data {
-          ...InvoiceDataFragment
-        }
+        ...InvoiceFragment
       }
     }
   }
   
-    ${InvoiceData.FRAGMENT}
+    ${Invoice.FRAGMENT}
 """

--- a/lightspark-sdk/src/commonTest/kotlin/com/lightspark/sdk/ClientIntegrationTests.kt
+++ b/lightspark-sdk/src/commonTest/kotlin/com/lightspark/sdk/ClientIntegrationTests.kt
@@ -168,9 +168,9 @@ class ClientIntegrationTests {
             "Pizza!",
         )
 
-        println("encoded invoice: ${paymentRequest.encodedPaymentRequest}")
+        println("encoded invoice: ${paymentRequest.data.encodedPaymentRequest}")
 
-        val decoded = client.decodeInvoice(paymentRequest.encodedPaymentRequest)
+        val decoded = client.decodeInvoice(paymentRequest.data.encodedPaymentRequest)
         decoded.shouldNotBeNull()
         println("decoded invoice: $decoded")
     }
@@ -181,7 +181,7 @@ class ClientIntegrationTests {
         val metadata = "[[\\\"text/plain\\\",\\\"Pay to domain.org user ktfan98\\\"],[\\\"text/identifier\\\",\\\"ktfan98@domain.org\\\"]]"
         val paymentRequest = client.createLnurlInvoice(node.id, 1000, metadata)
 
-        println("encoded invoice: ${paymentRequest.encodedPaymentRequest}")
+        println("encoded invoice: ${paymentRequest.data.encodedPaymentRequest}")
     }
 
     @Test
@@ -232,7 +232,7 @@ class ClientIntegrationTests {
         val unlocked = client.recoverNodeSigningKey(node.id, NODE_PASSWORD)
         unlocked.shouldBeTrue()
         val invoice = client.createInvoice(node.id, 100_000, "test invoice")
-        val payment = client.createTestModePayment(node.id, invoice.encodedPaymentRequest)
+        val payment = client.createTestModePayment(node.id, invoice.data.encodedPaymentRequest)
         payment.shouldNotBeNull()
         payment.status.shouldBeIn(TransactionStatus.PENDING, TransactionStatus.SUCCESS)
     }

--- a/wallet-sdk/src/androidUnitTest/kotlin/com/lightspark/sdk/wallet/ClientIntegrationTests.kt
+++ b/wallet-sdk/src/androidUnitTest/kotlin/com/lightspark/sdk/wallet/ClientIntegrationTests.kt
@@ -194,9 +194,9 @@ class ClientIntegrationTests {
             "Pizza!",
         )
 
-        println("encoded invoice: ${paymentRequest.encodedPaymentRequest}")
+        println("encoded invoice: ${paymentRequest.data.encodedPaymentRequest}")
 
-        val decoded = client.decodeInvoice(paymentRequest.encodedPaymentRequest)
+        val decoded = client.decodeInvoice(paymentRequest.data.encodedPaymentRequest)
         decoded.shouldNotBeNull()
         println("decoded invoice: $decoded")
     }
@@ -270,7 +270,7 @@ class ClientIntegrationTests {
         ensureWalletDeployedAndInitialized(output.wallet)
         client.loadWalletSigningKey(signingPrivKey!!.decodeBase64Bytes())
         val invoice = client.createInvoice(100_000, "test invoice")
-        val payment = client.createTestModePayment(invoice.encodedPaymentRequest)
+        val payment = client.createTestModePayment(invoice.data.encodedPaymentRequest)
         payment.shouldNotBeNull()
         payment.status.shouldBeIn(TransactionStatus.PENDING, TransactionStatus.SUCCESS)
     }

--- a/wallet-sdk/src/commonJvmAndroidMain/kotlin/com/lightspark/sdk/wallet/LightsparkFuturesWalletClient.kt
+++ b/wallet-sdk/src/commonJvmAndroidMain/kotlin/com/lightspark/sdk/wallet/LightsparkFuturesWalletClient.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.future
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
 
 /**
@@ -131,7 +130,7 @@ class LightsparkFuturesWalletClient constructor(config: ClientConfig) {
         keyType: KeyType,
         signingPublicKey: String,
         signingPrivateKey: String,
-        callback: (Wallet) -> Unit
+        callback: (Wallet) -> Unit,
     ): CompletableFuture<Wallet> =
         coroutineScope.future {
             var wallet: Wallet? = null
@@ -178,6 +177,7 @@ class LightsparkFuturesWalletClient constructor(config: ClientConfig) {
      * @param amountMsats The amount of the invoice in milli-satoshis.
      * @param memo Optional memo to include in the invoice.
      * @param type The type of invoice to create. Defaults to [InvoiceType.STANDARD].
+     * @param expirySecs The number of seconds until the invoice expires. Defaults to 1 day.
      * @return The invoice data.
      * @throws LightsparkAuthenticationException If the user is not authenticated.
      */
@@ -187,8 +187,9 @@ class LightsparkFuturesWalletClient constructor(config: ClientConfig) {
         amountMsats: Long,
         memo: String? = null,
         type: InvoiceType = InvoiceType.STANDARD,
-    ): CompletableFuture<InvoiceData> =
-        coroutineScope.future { coroutinesClient.createInvoice(amountMsats, memo, type) }
+        expirySecs: Int? = null,
+    ): CompletableFuture<Invoice> =
+        coroutineScope.future { coroutinesClient.createInvoice(amountMsats, memo, type, expirySecs) }
 
     /**
      * Pay a lightning invoice from the current wallet.

--- a/wallet-sdk/src/commonMain/kotlin/com/lightspark/sdk/wallet/LightsparkSyncWalletClient.kt
+++ b/wallet-sdk/src/commonMain/kotlin/com/lightspark/sdk/wallet/LightsparkSyncWalletClient.kt
@@ -136,7 +136,7 @@ class LightsparkSyncWalletClient constructor(config: ClientConfig) {
         keyType: KeyType,
         signingPublicKey: String,
         signingPrivateKey: String,
-        callback: (Wallet) -> Unit
+        callback: (Wallet) -> Unit,
     ) {
         runBlocking {
             asyncClient.initializeWalletAndWaitForInitialized(keyType, signingPublicKey, signingPrivateKey).collect {
@@ -179,6 +179,7 @@ class LightsparkSyncWalletClient constructor(config: ClientConfig) {
      * @param amountMsats The amount of the invoice in milli-satoshis.
      * @param memo Optional memo to include in the invoice.
      * @param type The type of invoice to create. Defaults to [InvoiceType.STANDARD].
+     * @param expirySecs The number of seconds until the invoice expires. Defaults to 1 day.
      * @return The invoice data.
      * @throws LightsparkAuthenticationException If the user is not authenticated.
      */
@@ -188,7 +189,8 @@ class LightsparkSyncWalletClient constructor(config: ClientConfig) {
         amountMsats: Long,
         memo: String? = null,
         type: InvoiceType = InvoiceType.STANDARD,
-    ): InvoiceData = runBlocking { asyncClient.createInvoice(amountMsats, memo, type) }
+        expirySecs: Int? = null,
+    ): Invoice = runBlocking { asyncClient.createInvoice(amountMsats, memo, type, expirySecs) }
 
     /**
      * Pay a lightning invoice from the current wallet.

--- a/wallet-sdk/src/commonMain/kotlin/com/lightspark/sdk/wallet/graphql/CreateInvoice.kt
+++ b/wallet-sdk/src/commonMain/kotlin/com/lightspark/sdk/wallet/graphql/CreateInvoice.kt
@@ -1,21 +1,21 @@
 package com.lightspark.sdk.wallet.graphql
 
-import com.lightspark.sdk.wallet.model.InvoiceData
+import com.lightspark.sdk.wallet.model.Invoice
 
 const val CreateInvoiceMutation = """
   mutation CreateInvoice(
     ${'$'}amountMsats: Long!
     ${'$'}memo: String
     ${'$'}type: InvoiceType = null
+    ${'$'}expirySecs: Int = null
     ) {
-    create_invoice(input: { amount_msats: ${'$'}amountMsats, memo: ${'$'}memo, invoice_type: ${'$'}type }) {
+    ) {
+    create_invoice(input: { amount_msats: ${'$'}amountMsats, memo: ${'$'}memo, invoice_type: ${'$'}type }, expiry_secs: ${'$'}expirySecs) {
       invoice {
-        data {
-          ...InvoiceDataFragment
-        }
+        ...InvoiceFragment
       }
     }
   }
   
-    ${InvoiceData.FRAGMENT}
+    ${Invoice.FRAGMENT}
 """


### PR DESCRIPTION
This allows access to the invoice ID, which may be useful later in retrieving updated invoice data.

Also exposing the expirySecs param in the process so that clients can override the expiration value.