### PR TITLE
adding sender vasp demo endpoints

### DIFF
--- a/umaserverdemo/src/main/kotlin/com/lightspark/ReceivingVasp.kt
+++ b/umaserverdemo/src/main/kotlin/com/lightspark/ReceivingVasp.kt
@@ -134,8 +134,8 @@ class ReceivingVasp(
             return "failed to fetch $umaEndpoint"
         }
         if (response.status != HttpStatusCode.OK) {
-            call.respond(HttpStatusCode.InternalServerError, "Payreq to Sending Vasp: ${response.status}")
-            return "Payreq to sending vasp failed: ${response.status}"
+            call.respond(HttpStatusCode.InternalServerError, "Payreq to Sending Vasp failed: ${response.status}")
+            return "Payreq to sending failed: ${response.status}"
         }
         call.respond(response.body())
         return "OK"
@@ -163,9 +163,9 @@ class ReceivingVasp(
             return HttpStatusCode.BadRequest to "CurrencyCode not provided."
         }
 
-        val expiresIn2Days = Clock.System.now().plus(2, DateTimeUnit.HOUR*24) //?
+        val expiresIn2Days = Clock.System.now().plus(2, DateTimeUnit.HOUR*24)
 
-        val receiverUma = "${config.username}:${getReceivingVaspDomain(call)}"
+        val receiverUma = buildReceiverUma(call)
 
         val invoice = uma.getInvoice(
             receiverUma = receiverUma,
@@ -186,6 +186,7 @@ class ReceivingVasp(
             privateSigningKey = config.umaSigningPrivKey,
             senderUma = senderUma
         )
+
         return HttpStatusCode.OK to invoice.toBech32()
     }
 
@@ -370,6 +371,7 @@ class ReceivingVasp(
             return "Invalid payreq signature."
         }
 
+        senderUmaVersion = UMA_VERSION_STRING
         val receivingCurrency = getReceivingCurrencies(senderUmaVersion)
             .firstOrNull { it.code == request.receivingCurrencyCode() } ?: run {
             call.respond(HttpStatusCode.BadRequest, "Unsupported currency.")
@@ -472,6 +474,8 @@ class ReceivingVasp(
         val path = uri
         return "$protocol://$host$port$path"
     }
+
+    private fun buildReceiverUma(call: ApplicationCall) = "$${config.username}@${getReceivingVaspDomain(call)}"
 
     private fun getReceivingVaspDomain(call: ApplicationCall) = config.vaspDomain ?: call.originWithPort()
 }

--- a/umaserverdemo/src/main/kotlin/com/lightspark/ReceivingVasp.kt
+++ b/umaserverdemo/src/main/kotlin/com/lightspark/ReceivingVasp.kt
@@ -183,7 +183,7 @@ class ReceivingVasp(
             receivingCurrency = InvoiceCurrency(
                 currency.code, currency.name, currency.symbol, currency.decimals
             ),
-            expiration = expiresIn2Days.toEpochMilliseconds(),
+            expiration = expiresIn2Days.epochSeconds,
             isSubjectToTravelRule = true,
             requiredPayerData = createCounterPartyDataOptions(
                 "name" to false,

--- a/umaserverdemo/src/main/kotlin/com/lightspark/ReceivingVasp.kt
+++ b/umaserverdemo/src/main/kotlin/com/lightspark/ReceivingVasp.kt
@@ -90,6 +90,11 @@ class ReceivingVasp(
             call.respond(HttpStatusCode.BadRequest, "SenderUma not provided.")
             return "SenderUma not provided."
         }
+        val senderUmaComponents = senderUma.split("@")
+        if (senderUmaComponents.size != 2) {
+            call.respond(HttpStatusCode.BadRequest, "SenderUma format invalid: $senderUma.")
+            return "SenderUma format invalid: $senderUma."
+        }
         val (status, data) = createUmaInvoice(call, senderUma)
         if (status != HttpStatusCode.OK) {
             call.respond(status, data)
@@ -161,6 +166,10 @@ class ReceivingVasp(
             }
         } ?: run {
             return HttpStatusCode.BadRequest to "CurrencyCode not provided."
+        }
+        
+        if (amount < currency.minSendable() || amount > currency.maxSendable()) {
+            return HttpStatusCode.BadRequest to "CurrencyCode amount is outside of sendable range."
         }
 
         val expiresIn2Days = Clock.System.now().plus(2, DateTimeUnit.HOUR*24)

--- a/umaserverdemo/src/main/kotlin/com/lightspark/SendingVasp.kt
+++ b/umaserverdemo/src/main/kotlin/com/lightspark/SendingVasp.kt
@@ -232,7 +232,7 @@ class SendingVasp(
             return "Failed to fetch public keys."
         }
         if (!uma.verifyUmaInvoice(umaInvoice, receiverVaspPubKeys)) {
-            call.respond(HttpStatusCode.BadRequest, "Unable to decode invoice.")
+            call.respond(HttpStatusCode.BadRequest, "Invalid invoice signature.")
             return "Unable to decode invoice."
         }
         requestDataCache.saveUmaInvoice(umaInvoice.invoiceUUID, umaInvoice)

--- a/umaserverdemo/src/main/kotlin/com/lightspark/SendingVasp.kt
+++ b/umaserverdemo/src/main/kotlin/com/lightspark/SendingVasp.kt
@@ -50,6 +50,7 @@ import me.uma.UMA_VERSION_STRING
 import me.uma.UmaProtocolHelper
 import me.uma.protocol.CounterPartyDataOptions
 import me.uma.protocol.CurrencySerializer
+import me.uma.protocol.Invoice
 import me.uma.protocol.KycStatus
 import me.uma.protocol.PayRequest
 import me.uma.protocol.UtxoWithAmount
@@ -71,15 +72,166 @@ class SendingVasp(
             )
         }
     }
-    private val requestDataCache = Vasp1RequestCache()
+    private val requestDataCache = SendingVaspRequestCache()
     private val nonceCache = InMemoryNonceCache(Clock.System.now().epochSeconds)
     private lateinit var receiverUmaVersion: String
 
     suspend fun payInvoice(call: ApplicationCall): String {
+        // or get it from the cache
+        val umaInvoice = call.request.queryParameters["invoice"]?.let { invoiceStr ->
+            // handle the case where users have provided the uuid of a cached invoice, rather
+            // than a full bech32 encoded invoice
+            if (!invoiceStr.startsWith("uma")) {
+                requestDataCache.getUmaInvoiceData(invoiceStr)
+            } else {
+                Invoice.fromBech32(invoiceStr)
+            }
+        } ?: run {
+            call.respond(HttpStatusCode.BadRequest, "Unable to decode invoice.")
+            return "Unable to decode invoice."
+        }
+        println(umaInvoice.receiverUma)
+        val receiverVaspDomain = umaInvoice.receiverUma.split("@").getOrNull(1) ?: run {
+            call.respond(HttpStatusCode.FailedDependency, "Failed to parse receiver vasp.")
+            return "Failed to parse receiver vasp."
+        }
+        val receiverVaspPubKeys = try {
+            uma.fetchPublicKeysForVasp(receiverVaspDomain)
+        } catch (e: Exception) {
+            call.application.environment.log.error("Failed to fetch pubkeys", e)
+            call.respond(HttpStatusCode.FailedDependency, "Failed to fetch public keys.")
+            return "Failed to fetch public keys."
+        }
+        if (!uma.verifyUmaInvoice(umaInvoice, receiverVaspPubKeys)) {
+            call.respond(HttpStatusCode.BadRequest, "Unable to decode invoice.")
+            return "Unable to decode invoice."
+        }
+
+        val payer = getPayerProfile(umaInvoice.requiredPayerData ?: emptyMap(), call)
+        // initial request data is cached in request and pay invoice
+
+        val currencyValid = getReceivingCurrencies(UMA_VERSION_STRING).any {
+            it.code == umaInvoice.receivingCurrency.code
+        }
+        if (!currencyValid) {
+            call.respond(HttpStatusCode.BadRequest, "Receiving currency code not supported.")
+            return "Receiving currency code not supported."
+        }
+
+        val trInfo = "Here is some fake travel rule info. It's up to you to actually implement this if needed."
+        val payerUtxos = emptyList<String>()
+
+        val isAmountInMsats = call.request.queryParameters["isAmountInMsats"]?.toBoolean() ?:
+        (umaInvoice.receivingCurrency.code == "SAT")
+
+        val payReq = uma.getPayRequest(
+            receiverEncryptionPubKey = receiverVaspPubKeys.getEncryptionPublicKey(),
+            sendingVaspPrivateKey = config.umaSigningPrivKey,
+            receivingCurrencyCode = umaInvoice.receivingCurrency.code,
+            isAmountInReceivingCurrency = !isAmountInMsats,
+            amount = umaInvoice.amount,
+            payerIdentifier = payer.identifier,
+            payerKycStatus = KycStatus.VERIFIED,
+            payerNodePubKey = getNodePubKey(),
+            utxoCallback = getUtxoCallback(call, "1234abc"),
+            travelRuleInfo = trInfo,
+            payerUtxos = payerUtxos,
+            payerName = payer.name,
+            payerEmail = payer.email,
+            comment = call.request.queryParameters["comment"],
+            receiverUmaVersion = umaInvoice.umaVersion,
+        )
+
+
+        val response = try {
+            httpClient.post(umaInvoice.callback) {
+                contentType(ContentType.Application.Json)
+                setBody(payReq.toJson())
+            }
+        } catch (e: Exception) {
+            call.respond(HttpStatusCode.FailedDependency, "Unable to connect to ${umaInvoice.callback}")
+            return "Unable to connect to ${umaInvoice.callback}"
+        }
+        if (response.status != HttpStatusCode.OK) {
+            call.respond(HttpStatusCode.InternalServerError, "Payreq to receiving vasp failed: ${response.status}")
+            return "Payreq to receiving vasp failed: ${response.status}"
+        }
+
+        val payReqResponse = try {
+            uma.parseAsPayReqResponse(response.body())
+        } catch (e: Exception) {
+            call.respond(HttpStatusCode.InternalServerError, "Failed to parse payreq response.")
+            return "Failed to parse payreq response."
+        }
+
+        if (!payReqResponse.isUmaResponse()) {
+            call.application.environment.log.error("Got a non-UMA response: ${payReqResponse.toJson()}")
+            call.respond(HttpStatusCode.FailedDependency, "Received non-UMA response from vasp2 for an UMA request")
+            return "Received non-UMA response from receiving vasp."
+        }
+
+        try {
+            uma.verifyPayReqResponseSignature(payReqResponse, receiverVaspPubKeys, payer.identifier, nonceCache)
+        } catch (e: Exception) {
+            call.respond(HttpStatusCode.BadRequest, "Failed to verify lnurlp response signature.")
+            return "Failed to verify lnurlp response signature."
+        }
+
+        val invoice = try {
+            lightsparkClient.decodeInvoice(payReqResponse.encodedInvoice)
+        } catch (e: Exception) {
+            call.application.environment.log.error("Failed to decode invoice", e)
+            call.respond(HttpStatusCode.InternalServerError, "Failed to decode invoice.")
+            return "Failed to decode invoice."
+        }
+
+        val newCallbackId = requestDataCache.savePayReqData(
+            encodedInvoice = payReqResponse.encodedInvoice,
+            utxoCallback = getUtxoCallback(call, "1234abc"),
+            invoiceData = invoice,
+        )
+
+        // we've successfully fulfilled this request, so remove cached invoice uuid data
+        requestDataCache.removeUmaInvoiceData(umaInvoice.invoiceUUID)
+
+        call.respond(
+            buildJsonObject {
+                put("encodedInvoice", payReqResponse.encodedInvoice)
+                put("callbackUuid", newCallbackId)
+                put("amountMsats", invoice.amount.toMilliSats())
+                put("amountReceivingCurrency", payReqResponse.paymentInfo?.amount ?: umaInvoice.amount)
+                put("receivingCurrencyDecimals", payReqResponse.paymentInfo?.decimals ?: 0)
+                put("exchangeFeesMsats", payReqResponse.paymentInfo?.exchangeFeesMillisatoshi ?: 0)
+                put("conversionRate", payReqResponse.paymentInfo?.multiplier ?: 1000)
+                put("receivingCurrencyCode", payReqResponse.paymentInfo?.currencyCode ?: "SAT")
+            },
+        )
+
         return "OK"
     }
 
     suspend fun requestInvoicePayment(call: ApplicationCall): String {
+        val umaInvoice = call.request.queryParameters["invoice"]?.let(Invoice::fromBech32) ?: run {
+            call.respond(HttpStatusCode.BadRequest, "Unable to decode invoice.")
+            return "Unable to decode invoice."
+        }
+        print(umaInvoice)
+        val receiverVaspDomain = umaInvoice.receiverUma.split("@").getOrNull(1) ?: run {
+            call.respond(HttpStatusCode.FailedDependency, "Failed to parse receiver vasp.")
+            return "Failed to parse receiver vasp."
+        }
+        val receiverVaspPubKeys = try {
+            uma.fetchPublicKeysForVasp(receiverVaspDomain)
+        } catch (e: Exception) {
+            call.application.environment.log.error("Failed to fetch pubkeys", e)
+            call.respond(HttpStatusCode.FailedDependency, "Failed to fetch public keys.")
+            return "Failed to fetch public keys."
+        }
+        if (!uma.verifyUmaInvoice(umaInvoice, receiverVaspPubKeys)) {
+            call.respond(HttpStatusCode.BadRequest, "Unable to decode invoice.")
+            return "Unable to decode invoice."
+        }
+        requestDataCache.saveUmaInvoice(umaInvoice.invoiceUUID, umaInvoice)
         return "OK"
     }
 
@@ -233,9 +385,9 @@ class SendingVasp(
         // The default for UMA requests should be to assume the receiving currency, but for non-UMA, we default to msats.
         val isAmountInMsats = call.request.queryParameters["isAmountInMsats"]?.toBoolean() ?: !isUma
 
-        val vasp2PubKeys = if (isUma) {
+        val receiverVaspPubKeys = if (isUma) {
             try {
-                uma.fetchPublicKeysForVasp(initialRequestData.vasp2Domain)
+                uma.fetchPublicKeysForVasp(initialRequestData.receivingVaspDomain)
             } catch (e: Exception) {
                 call.application.environment.log.error("Failed to fetch pubkeys", e)
                 call.respond(HttpStatusCode.FailedDependency, "Failed to fetch public keys.")
@@ -252,7 +404,7 @@ class SendingVasp(
         val payReq = try {
             if (isUma) {
                 uma.getPayRequest(
-                    receiverEncryptionPubKey = vasp2PubKeys!!.getEncryptionPublicKey(),
+                    receiverEncryptionPubKey = receiverVaspPubKeys!!.getEncryptionPublicKey(),
                     sendingVaspPrivateKey = config.umaSigningPrivKey,
                     receivingCurrencyCode = currencyCode,
                     isAmountInReceivingCurrency = !isAmountInMsats,
@@ -319,7 +471,7 @@ class SendingVasp(
 
         if (isUma) {
             try {
-                uma.verifyPayReqResponseSignature(payReqResponse, vasp2PubKeys!!, payer.identifier, nonceCache)
+                uma.verifyPayReqResponseSignature(payReqResponse, receiverVaspPubKeys!!, payer.identifier, nonceCache)
             } catch (e: Exception) {
                 call.respond(HttpStatusCode.BadRequest, "Failed to verify lnurlp response signature.")
                 return "Failed to verify lnurlp response signature."
@@ -429,7 +581,7 @@ class SendingVasp(
 
     private suspend fun sendPostTransactionCallback(
         payment: OutgoingPayment,
-        payReqData: Vasp1PayReqData,
+        payReqData: SendingVaspPayReqData,
         call: ApplicationCall,
     ) {
         val utxos = payment.umaPostTransactionData?.map {

--- a/umaserverdemo/src/main/kotlin/com/lightspark/SendingVasp.kt
+++ b/umaserverdemo/src/main/kotlin/com/lightspark/SendingVasp.kt
@@ -104,7 +104,7 @@ class SendingVasp(
             call.respond(HttpStatusCode.BadRequest, "Unable to decode invoice.")
             return "Unable to decode invoice."
         }
-        if (umaInvoice.expiration < Clock.System.now().toEpochMilliseconds()) {
+        if (umaInvoice.expiration < Clock.System.now().epochSeconds) {
             call.respond(HttpStatusCode.BadRequest, "Invoice ${umaInvoice.invoiceUUID} has expired.")
             return "Invoice ${umaInvoice.invoiceUUID} has expired."
         }
@@ -219,7 +219,6 @@ class SendingVasp(
             call.respond(HttpStatusCode.BadRequest, "Unable to decode invoice.")
             return "Unable to decode invoice."
         }
-        print(umaInvoice)
         val receiverVaspDomain = umaInvoice.receiverUma.split("@").getOrNull(1) ?: run {
             call.respond(HttpStatusCode.FailedDependency, "Failed to parse receiver vasp.")
             return "Failed to parse receiver vasp."

--- a/umaserverdemo/src/main/kotlin/com/lightspark/SendingVasp.kt
+++ b/umaserverdemo/src/main/kotlin/com/lightspark/SendingVasp.kt
@@ -215,7 +215,7 @@ class SendingVasp(
     }
 
     suspend fun requestInvoicePayment(call: ApplicationCall): String {
-        val umaInvoice = call.request.queryParameters["invoice"]?.let(Invoice::fromBech32) ?: run {
+        val umaInvoice = call.parameters["invoice"]?.let(Invoice::fromBech32) ?: run {
             call.respond(HttpStatusCode.BadRequest, "Unable to decode invoice.")
             return "Unable to decode invoice."
         }

--- a/umaserverdemo/src/main/kotlin/com/lightspark/SendingVaspRequestCache.kt
+++ b/umaserverdemo/src/main/kotlin/com/lightspark/SendingVaspRequestCache.kt
@@ -1,6 +1,7 @@
 package com.lightspark
 
 import com.lightspark.sdk.model.InvoiceData
+import me.uma.protocol.Invoice
 import java.util.UUID
 import me.uma.protocol.LnurlpResponse
 
@@ -8,40 +9,50 @@ import me.uma.protocol.LnurlpResponse
  * A simple in-memory cache for data that needs to be remembered between calls to VASP1. In practice, this would be
  * stored in a database or other persistent storage.
  */
-class Vasp1RequestCache {
+class SendingVaspRequestCache {
     /**
      *  This is a map of the UMA request UUID to the LnurlpResponse from that initial Lnurlp request.
      * 	This is used to cache the LnurlpResponse so that we can use it to generate the UMA payreq without the client
      * 	having to make another Lnurlp request or remember lots of details.
      * 	NOTE: In production, this should be stored in a database or other persistent storage.
      */
-    private val lnurlpRequestCache: MutableMap<String, Vasp1InitialRequestData> = mutableMapOf()
+    private val lnurlpRequestCache: MutableMap<String, SendingVaspInitialRequestData> = mutableMapOf()
 
     /**
      * This is a map of the UMA request UUID to the payreq data that we generated for that request.
      * This is used to cache the payreq data so that we can pay the invoice when the user confirms
      * NOTE: In production, this should be stored in a database or other persistent storage.
      */
-    private val payReqCache: MutableMap<String, Vasp1PayReqData> = mutableMapOf()
+    private val payReqCache: MutableMap<String, SendingVaspPayReqData> = mutableMapOf()
 
-    fun getLnurlpResponseData(uuid: String): Vasp1InitialRequestData? {
+    private val umaInvoiceCache: MutableMap<String, Invoice> = mutableMapOf()
+
+    fun getLnurlpResponseData(uuid: String): SendingVaspInitialRequestData? {
         return lnurlpRequestCache[uuid]
     }
 
-    fun getPayReqData(uuid: String): Vasp1PayReqData? {
+    fun getPayReqData(uuid: String): SendingVaspPayReqData? {
         return payReqCache[uuid]
+    }
+
+    fun getUmaInvoiceData(uuid: String): Invoice? {
+        return umaInvoiceCache[uuid]
     }
 
     fun saveLnurlpResponseData(lnurlpResponse: LnurlpResponse, receiverId: String, vasp2Domain: String): String {
         val uuid = UUID.randomUUID().toString()
-        lnurlpRequestCache[uuid] = Vasp1InitialRequestData(lnurlpResponse, receiverId, vasp2Domain)
+        lnurlpRequestCache[uuid] = SendingVaspInitialRequestData(lnurlpResponse, receiverId, vasp2Domain)
         return uuid
     }
 
     fun savePayReqData(encodedInvoice: String, utxoCallback: String, invoiceData: InvoiceData): String {
         val uuid = UUID.randomUUID().toString()
-        payReqCache[uuid] = Vasp1PayReqData(encodedInvoice, utxoCallback, invoiceData)
+        payReqCache[uuid] = SendingVaspPayReqData(encodedInvoice, utxoCallback, invoiceData)
         return uuid
+    }
+
+    fun saveUmaInvoice(uuid: String, invoice: Invoice) {
+        umaInvoiceCache[uuid] = invoice
     }
 
     fun removeLnurlpResponseData(uuid: String) {
@@ -51,15 +62,19 @@ class Vasp1RequestCache {
     fun removePayReqData(uuid: String) {
         payReqCache.remove(uuid)
     }
+
+    fun removeUmaInvoiceData(uuid: String) {
+        umaInvoiceCache.remove(uuid)
+    }
 }
 
-data class Vasp1InitialRequestData(
+data class SendingVaspInitialRequestData(
     val lnurlpResponse: LnurlpResponse,
     val receiverId: String,
-    val vasp2Domain: String,
+    val receivingVaspDomain: String,
 )
 
-data class Vasp1PayReqData(
+data class SendingVaspPayReqData(
     val encodedInvoice: String,
     val utxoCallback: String,
     val invoiceData: InvoiceData,


### PR DESCRIPTION
# Sender VASP demo endpoints

this adds 2 demo endpoints 
- receive an invoice from a receiver vasp and cache it for later client payment
- process a payrequest for a full incoming uma invoice, or a cached invoice

# testing
run 2 vasps, a receiver vasp on 8080 and a sender vasp on 8081

receiver invoice to sender vasp
`curl -u <username>:<password> -X POST "http://localhost:8081/api/uma/request_and_pay_invoice?invoice=<bech32 encoded invoice>"`

sender client to sender vasp:
`curl -u <username>:<password> -X POST "http://localhost:8081/api/uma/pay_invoice?invoice=<bech32 encoded invoice, or uuid identifying a cached invoice>`