### PR TITLE
Added paymentHash and preimageNonce params to createInvoice functions

### DIFF
--- a/lightspark-sdk/src/commonJvmAndroidMain/kotlin/com/lightspark/sdk/LightsparkFuturesClient.kt
+++ b/lightspark-sdk/src/commonJvmAndroidMain/kotlin/com/lightspark/sdk/LightsparkFuturesClient.kt
@@ -126,6 +126,8 @@ class LightsparkFuturesClient(config: ClientConfig) {
      * @param memo Optional memo to include in the invoice.
      * @param type The type of invoice to create. Defaults to [InvoiceType.STANDARD].
      * @param expirySecs The number of seconds until the invoice expires. Defaults to 1 day.
+     * @param paymentHash Optional payment hash to include in the invoice.
+     * @param preimageNonce Optional preimage nonce to include in the invoice.
      */
     @JvmOverloads
     fun createInvoice(
@@ -134,8 +136,20 @@ class LightsparkFuturesClient(config: ClientConfig) {
         memo: String? = null,
         type: InvoiceType = InvoiceType.STANDARD,
         expirySecs: Int? = null,
+        paymentHash: String? = null,
+        preimageNonce: String? = null,
     ): CompletableFuture<Invoice> =
-        coroutineScope.future { coroutinesClient.createInvoice(nodeId, amountMsats, memo, type, expirySecs) }
+        coroutineScope.future {
+            coroutinesClient.createInvoice(
+                nodeId,
+                amountMsats,
+                memo,
+                type,
+                expirySecs,
+                paymentHash,
+                preimageNonce,
+            )
+        }
 
     /**
      * Creates a Lightning invoice for the given node. This should only be used for generating invoices for LNURLs, with
@@ -146,6 +160,8 @@ class LightsparkFuturesClient(config: ClientConfig) {
      * @param metadata The LNURL metadata payload field from the initial payreq response. This will be hashed and
      *      present in the h-tag (SHA256 purpose of payment) of the resulting Bolt 11 invoice.
      * @param expirySecs The number of seconds until the invoice expires. Defaults to 1 day.
+     * @param paymentHash Optional payment hash to include in the invoice.
+     * @param preimageNonce Optional preimage nonce to include in the invoice.
      */
     @JvmOverloads
     fun createLnurlInvoice(
@@ -153,6 +169,8 @@ class LightsparkFuturesClient(config: ClientConfig) {
         amountMsats: Long,
         metadata: String,
         expirySecs: Int? = null,
+        paymentHash: String? = null,
+        preimageNonce: String? = null,
     ): CompletableFuture<Invoice> =
         coroutineScope.future {
             coroutinesClient.createLnurlInvoice(
@@ -160,6 +178,8 @@ class LightsparkFuturesClient(config: ClientConfig) {
                 amountMsats,
                 metadata,
                 expirySecs,
+                paymentHash,
+                preimageNonce,
             )
         }
 
@@ -175,6 +195,8 @@ class LightsparkFuturesClient(config: ClientConfig) {
      * @param signingPrivateKey The receiver's signing private key. Used to hash the receiver identifier.
      * @param receiverIdentifier Optional identifier of the receiver. If provided, this will be hashed using a
      *      monthly-rotated seed and used for anonymized analysis.
+     * @param paymentHash Optional payment hash to include in the invoice.
+     * @param preimageNonce Optional preimage nonce to include in the invoice.
      */
     @JvmOverloads
     @Throws(IllegalArgumentException::class)
@@ -185,6 +207,8 @@ class LightsparkFuturesClient(config: ClientConfig) {
         expirySecs: Int? = null,
         signingPrivateKey: ByteArray? = null,
         receiverIdentifier: String? = null,
+        paymentHash: String? = null,
+        preimageNonce: String? = null,
     ): CompletableFuture<Invoice> =
         coroutineScope.future {
             coroutinesClient.createUmaInvoice(
@@ -194,6 +218,8 @@ class LightsparkFuturesClient(config: ClientConfig) {
                 expirySecs,
                 signingPrivateKey,
                 receiverIdentifier,
+                paymentHash,
+                preimageNonce,
             )
         }
 

--- a/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/LightsparkCoroutinesClient.kt
+++ b/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/LightsparkCoroutinesClient.kt
@@ -182,6 +182,8 @@ class LightsparkCoroutinesClient private constructor(
      * @param memo Optional memo to include in the invoice.
      * @param type The type of invoice to create. Defaults to [InvoiceType.STANDARD].
      * @param expirySecs The number of seconds until the invoice expires. Defaults to 1 day.
+     * @param paymentHash Optional payment hash to include in the invoice.
+     * @param preimageNonce Optional preimage nonce to include in the invoice.
      */
     suspend fun createInvoice(
         nodeId: String,
@@ -189,6 +191,8 @@ class LightsparkCoroutinesClient private constructor(
         memo: String? = null,
         type: InvoiceType = InvoiceType.STANDARD,
         expirySecs: Int? = null,
+        paymentHash: String? = null,
+        preimageNonce: String? = null,
     ): Invoice {
         requireValidAuth()
         return executeQuery(
@@ -200,6 +204,8 @@ class LightsparkCoroutinesClient private constructor(
                     memo?.let { add("memo", memo) }
                     add("type", serializerFormat.encodeToJsonElement(type))
                     expirySecs?.let { add("expirySecs", expirySecs) }
+                    paymentHash?.let { add("paymentHash", paymentHash) }
+                    preimageNonce?.let { add("preimageNonce", preimageNonce) }
                 },
             ) {
                 val invoiceJson =
@@ -220,12 +226,16 @@ class LightsparkCoroutinesClient private constructor(
      * @param metadata The LNURL metadata payload field from the initial payreq response. This will be hashed and
      *      present in the h-tag (SHA256 purpose of payment) of the resulting Bolt 11 invoice.
      * @param expirySecs The number of seconds until the invoice expires. Defaults to 1 day.
+     * @param paymentHash Optional payment hash to include in the invoice.
+     * @param preimageNonce Optional preimage nonce to include in the invoice.
      */
     suspend fun createLnurlInvoice(
         nodeId: String,
         amountMsats: Long,
         metadata: String,
         expirySecs: Int? = null,
+        paymentHash: String? = null,
+        preimageNonce: String? = null,
     ): Invoice {
         requireValidAuth()
 
@@ -241,6 +251,8 @@ class LightsparkCoroutinesClient private constructor(
                     add("amountMsats", amountMsats)
                     add("metadataHash", metadataHash)
                     expirySecs?.let { add("expirySecs", expirySecs) }
+                    paymentHash?.let { add("paymentHash", paymentHash) }
+                    preimageNonce?.let { add("preimageNonce", preimageNonce) }
                 },
             ) {
                 val invoiceJson =
@@ -264,6 +276,8 @@ class LightsparkCoroutinesClient private constructor(
      * @param signingPrivateKey The receiver's signing private key. Used to hash the receiver identifier.
      * @param receiverIdentifier Optional identifier of the receiver. If provided, this will be hashed using a
      *      monthly-rotated seed and used for anonymized analysis.
+     * @param paymentHash Optional payment hash to include in the invoice.
+     * @param preimageNonce Optional preimage nonce to include in the invoice.
      */
     @Throws(IllegalArgumentException::class)
     suspend fun createUmaInvoice(
@@ -273,6 +287,8 @@ class LightsparkCoroutinesClient private constructor(
         expirySecs: Int? = null,
         signingPrivateKey: ByteArray? = null,
         receiverIdentifier: String? = null,
+        paymentHash: String? = null,
+        preimageNonce: String? = null,
     ): Invoice {
         requireValidAuth()
 
@@ -296,6 +312,8 @@ class LightsparkCoroutinesClient private constructor(
                     add("metadataHash", metadataHash)
                     expirySecs?.let { add("expirySecs", expirySecs) }
                     receiverHash?.let { add("receiverHash", receiverHash) }
+                    paymentHash?.let { add("paymentHash", paymentHash) }
+                    preimageNonce?.let { add("preimageNonce", preimageNonce) }
                 },
             ) {
                 val invoiceJson =

--- a/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/LightsparkSyncClient.kt
+++ b/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/LightsparkSyncClient.kt
@@ -108,6 +108,8 @@ class LightsparkSyncClient constructor(config: ClientConfig) {
      * @param memo Optional memo to include in the invoice.
      * @param type The type of invoice to create. Defaults to [InvoiceType.STANDARD].
      * @param expirySecs The number of seconds until the invoice expires. Defaults to 1 day.
+     * @param paymentHash Optional payment hash to include in the invoice.
+     * @param preimageNonce Optional preimage nonce to include in the invoice.
      */
     @JvmOverloads
     fun createInvoice(
@@ -116,7 +118,19 @@ class LightsparkSyncClient constructor(config: ClientConfig) {
         memo: String? = null,
         type: InvoiceType = InvoiceType.STANDARD,
         expirySecs: Int? = null,
-    ): Invoice = runBlocking { asyncClient.createInvoice(nodeId, amountMsats, memo, type, expirySecs) }
+        paymentHash: String? = null,
+        preimageNonce: String? = null,
+    ): Invoice = runBlocking {
+        asyncClient.createInvoice(
+            nodeId,
+            amountMsats,
+            memo,
+            type,
+            expirySecs,
+            paymentHash,
+            preimageNonce,
+        )
+    }
 
     /**
      * Creates a Lightning invoice for the given node. This should only be used for generating invoices for LNURLs, with
@@ -127,6 +141,8 @@ class LightsparkSyncClient constructor(config: ClientConfig) {
      * @param metadata The LNURL metadata payload field from the initial payreq response. This will be hashed and
      * present in the h-tag (SHA256 purpose of payment) of the resulting Bolt 11 invoice.
      * @param expirySecs The number of seconds until the invoice expires. Defaults to 1 day.
+     * @param paymentHash Optional payment hash to include in the invoice.
+     * @param preimageNonce Optional preimage nonce to include in the invoice.
      */
     @JvmOverloads
     fun createLnurlInvoice(
@@ -134,12 +150,16 @@ class LightsparkSyncClient constructor(config: ClientConfig) {
         amountMsats: Long,
         metadata: String,
         expirySecs: Int? = null,
+        paymentHash: String? = null,
+        preimageNonce: String? = null,
     ): Invoice = runBlocking {
         asyncClient.createLnurlInvoice(
             nodeId,
             amountMsats,
             metadata,
             expirySecs,
+            paymentHash,
+            preimageNonce,
         )
     }
 
@@ -155,6 +175,8 @@ class LightsparkSyncClient constructor(config: ClientConfig) {
      * @param signingPrivateKey The receiver's signing private key. Used to hash the receiver identifier.
      * @param receiverIdentifier Optional identifier of the receiver. If provided, this will be hashed using a
      *      monthly-rotated seed and used for anonymized analysis.
+     * @param paymentHash Optional payment hash to include in the invoice.
+     * @param preimageNonce Optional preimage nonce to include in the invoice.
      */
     @JvmOverloads
     @Throws(IllegalArgumentException::class)
@@ -165,6 +187,8 @@ class LightsparkSyncClient constructor(config: ClientConfig) {
         expirySecs: Int? = null,
         signingPrivateKey: ByteArray? = null,
         receiverIdentifier: String? = null,
+        paymentHash: String? = null,
+        preimageNonce: String? = null,
     ): Invoice = runBlocking {
         asyncClient.createUmaInvoice(
             nodeId,
@@ -173,6 +197,8 @@ class LightsparkSyncClient constructor(config: ClientConfig) {
             expirySecs,
             signingPrivateKey,
             receiverIdentifier,
+            paymentHash,
+            preimageNonce,
         )
     }
 

--- a/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/graphql/CreateInvoice.kt
+++ b/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/graphql/CreateInvoice.kt
@@ -9,8 +9,19 @@ const val CreateInvoiceMutation = """
     ${'$'}memo: String
     ${'$'}type: InvoiceType = null
     ${'$'}expirySecs: Int = null
+    ${'$'}paymentHash: Hash32 = null
+    ${'$'}preimageNonce: Hash32 = null
     ) {
-    create_invoice(input: { node_id: ${'$'}nodeId, amount_msats: ${'$'}amountMsats, memo: ${'$'}memo, invoice_type: ${'$'}type, expiry_secs: ${'$'}expirySecs }) {
+    create_invoice(
+      input: {
+        node_id: ${'$'}nodeId
+        amount_msats: ${'$'}amountMsats
+        memo: ${'$'}memo
+        invoice_type: ${'$'}type
+        expiry_secs: ${'$'}expirySecs
+        payment_hash: ${'$'}paymentHash
+        preimage_nonce: ${'$'}preimageNonce
+      }) {
       invoice {
         ...InvoiceFragment
       }

--- a/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/graphql/CreateLnurlInvoice.kt
+++ b/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/graphql/CreateLnurlInvoice.kt
@@ -9,6 +9,8 @@ const val CreateLnurlInvoiceMutation = """
     ${'$'}metadataHash: String!
     ${'$'}expirySecs: Int = null
     ${'$'}receiverHash: String = null
+    ${'$'}paymentHash: Hash32 = null
+    ${'$'}preimageNonce: Hash32 = null
   ) {
     create_lnurl_invoice(
       input: {
@@ -17,7 +19,9 @@ const val CreateLnurlInvoiceMutation = """
         metadata_hash: ${'$'}metadataHash
         expiry_secs: ${'$'}expirySecs
         receiver_hash: ${'$'}receiverHash
-      }
+        payment_hash: ${'$'}paymentHash
+        preimage_nonce: ${'$'}preimageNonce
+      } 
     ) {
       invoice {
         ...InvoiceFragment

--- a/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/graphql/CreateUmaInvoice.kt
+++ b/lightspark-sdk/src/commonMain/kotlin/com/lightspark/sdk/graphql/CreateUmaInvoice.kt
@@ -9,6 +9,8 @@ const val CreateUmaInvoiceMutation = """
     ${'$'}metadataHash: String!
     ${'$'}expirySecs: Int = null
     ${'$'}receiverHash: String = null
+    ${'$'}paymentHash: Hash32 = null
+    ${'$'}preimageNonce: Hash32 = null
   ) {
     create_uma_invoice(
       input: {
@@ -17,6 +19,8 @@ const val CreateUmaInvoiceMutation = """
         metadata_hash: ${'$'}metadataHash
         expiry_secs: ${'$'}expirySecs
         receiver_hash: ${'$'}receiverHash
+        payment_hash: ${'$'}paymentHash
+        preimage_nonce: ${'$'}preimageNonce
       }
     ) {
       invoice {


### PR DESCRIPTION
Added paymentHash and preimageNonce params to createInvoice, createLnurlInvoice, and createUmaInvoice and their respective mutations from all 3 clients.

Used type of Hash32 on both parameters in order to match mutation input object types like:

<img width="559" alt="Screenshot 2025-03-25 at 1 56 36 PM" src="https://github.com/user-attachments/assets/dd17e930-fbb3-4309-877c-ff553b958ae7" />
