### PR TITLE
Update Gradle version to 8.14.2

### DIFF
--- a/androidwalletdemo/build.gradle.kts
+++ b/androidwalletdemo/build.gradle.kts
@@ -2,7 +2,6 @@ import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 import java.io.FileInputStream
 import java.util.*
 
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     id(libs.plugins.androidApplication.get().pluginId)
     kotlin("android")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,7 +1,6 @@
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import com.mgd.core.gradle.S3Upload
 
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     kotlin("multiplatform")
     alias(libs.plugins.kotlinSerialization)

--- a/crypto/build.gradle.kts
+++ b/crypto/build.gradle.kts
@@ -1,7 +1,6 @@
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import de.undercouch.gradle.tasks.download.Download
 
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     kotlin("multiplatform")
     id(libs.plugins.androidLibrary.get().pluginId)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 02 10:27:20 PST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/lightspark-sdk/build.gradle.kts
+++ b/lightspark-sdk/build.gradle.kts
@@ -1,7 +1,6 @@
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import com.mgd.core.gradle.S3Upload
 
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     kotlin("multiplatform")
     alias(libs.plugins.kotlinSerialization)

--- a/oauth/build.gradle.kts
+++ b/oauth/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     kotlin("android")
     id(libs.plugins.androidLibrary.get().pluginId)

--- a/wallet-sdk/build.gradle.kts
+++ b/wallet-sdk/build.gradle.kts
@@ -1,7 +1,6 @@
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import com.mgd.core.gradle.S3Upload
 
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     kotlin("multiplatform")
     alias(libs.plugins.kotlinSerialization)


### PR DESCRIPTION
The idea is to make it easier, in the next PR, to use a Gradle task to format our Java files.

This PR also removes all the `@Suppress("DSL_SCOPE_VIOLATION")` usages, because that's [not needed when using versions of Gradle >= 8.1](https://github.com/gradle/gradle/issues/22797).